### PR TITLE
fix(mongoose-schemas)unique setted false on _id

### DIFF
--- a/api/mongoose/Comment/index.js
+++ b/api/mongoose/Comment/index.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.commentsSchema = void 0;
 const mongoose_1 = require("mongoose");
 exports.commentsSchema = new mongoose_1.Schema({
-    _id: { type: mongoose_1.Schema.Types.ObjectId, required: true, unique: true, auto: true },
+    _id: { type: mongoose_1.Schema.Types.ObjectId, required: true, auto: true },
     postId: { type: mongoose_1.Schema.Types.ObjectId, required: true, ref: 'Post' },
     userId: { type: mongoose_1.Schema.Types.ObjectId, required: true, ref: 'User' },
     content: { type: String, required: true },

--- a/api/mongoose/Comment/index.ts
+++ b/api/mongoose/Comment/index.ts
@@ -2,7 +2,7 @@ import { Schema } from 'mongoose'
 import { IComments } from '../../types'
 
 export let commentsSchema = new Schema<IComments>({
-	_id: { type: Schema.Types.ObjectId, required: true, unique: true, auto: true},
+	_id: { type: Schema.Types.ObjectId, required: true, auto: true},
 	postId: { type: Schema.Types.ObjectId, required: true, ref: 'Post' },
 	userId: { type: Schema.Types.ObjectId, required: true, ref: 'User' },
 	content: { type: String, required: true },

--- a/api/mongoose/Post/index.js
+++ b/api/mongoose/Post/index.js
@@ -6,7 +6,6 @@ exports.postSchema = new mongoose_1.Schema({
     _id: {
         type: mongoose_1.Schema.Types.ObjectId,
         required: true,
-        unique: true,
         auto: true
     },
     userId: {

--- a/api/mongoose/Post/index.ts
+++ b/api/mongoose/Post/index.ts
@@ -5,7 +5,6 @@ export let postSchema = new Schema<IPost>({
 	_id: {
 		type: Schema.Types.ObjectId,
 		required: true,
-		unique: true,
 		auto: true
 	},
 	userId: {

--- a/api/mongoose/User/index.js
+++ b/api/mongoose/User/index.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.userSchema = void 0;
 const mongoose_1 = require("mongoose");
 exports.userSchema = new mongoose_1.Schema({
-    _id: { type: mongoose_1.Schema.Types.ObjectId, required: true, unique: true, auto: true },
+    _id: { type: mongoose_1.Schema.Types.ObjectId, required: true, auto: true },
     username: { type: String, required: true },
     email: { type: String, required: true, unique: true },
     firstname: { type: String, required: true },

--- a/api/mongoose/User/index.ts
+++ b/api/mongoose/User/index.ts
@@ -3,7 +3,7 @@ import { IUser } from "../../types";
 
 
 export let userSchema = new Schema<IUser>({
-    _id: {type:Schema.Types.ObjectId, required:true, unique:true, auto: true},
+    _id: {type:Schema.Types.ObjectId, required:true, auto: true},
     username: {type:String, required:true},
     email: {type:String, required:true, unique:true},
     firstname: {type:String, required:true},


### PR DESCRIPTION
Los _id en mongoose son únicos por default, y poner la opción de unique: true genera conflictos al generar una _id automáticamente, por lo que es necesario quitar esa opción.