### PR TITLE
landing fixes

### DIFF
--- a/client/src/pages/Landing/landing.jsx
+++ b/client/src/pages/Landing/landing.jsx
@@ -58,7 +58,7 @@ const Landing = () => {
       //console.log(arrOfReviewsToShow);
       let reviewObj = arrOfReviewsToShow[Math.floor(Math.random()*arrOfReviewsToShow.length)]
       if (!reviewObj || reviewObj === undefined) {
-        dispatch(getAllReviewes())
+        // dispatch(getAllReviewes())
       }
       return (
         arrOfReviewsToShow?.length ?

--- a/client/src/pages/Landing/landing.jsx
+++ b/client/src/pages/Landing/landing.jsx
@@ -54,14 +54,14 @@ const Landing = () => {
 
 
   let showReviews = ( ) =>{
-      let arrOfReviewsToShow = arrOfReviews?.filter(r => r?.stars >= 4 )
+      let arrOfReviewsToShow = arrOfReviews?.filter(r => r.stars >= 4 )
       //console.log(arrOfReviewsToShow);
       let reviewObj = arrOfReviewsToShow[Math.floor(Math.random()*arrOfReviewsToShow.length)]
       if (!reviewObj || reviewObj === undefined) {
         dispatch(getAllReviewes())
       }
       return (
-        reviewObj?.length ?
+        arrOfReviewsToShow?.length ?
       <div className="sn_review">
       <div className="star">
         <AiFillStar />


### PR DESCRIPTION
Se arregla una lectura undefined en la landing. 
Se rompía cuando se tenía solo reviews de menos de 4 estrellas.

También se comentó una una línea que llamaba constantemente a getAllReviews. Probar que esto no rompa nada